### PR TITLE
Fix issues #12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Added
 - ruby 2.4 testing (@majormoses)
+### Fixed
+- [iostat] Changes ouput in device session from 'Device:' to 'Device'. Fix issue  #12 (@dmichelotto)
 
 ## [1.0.1] - 2017-0702
 ### Fixed

--- a/bin/metrics-iostat-extended.rb
+++ b/bin/metrics-iostat-extended.rb
@@ -85,7 +85,7 @@ class IOStatExtended < Sensu::Plugin::Metric::CLI::Graphite
         headers = line.gsub(/%/, 'pct_').split(/\s+/)
         headers.shift
         next
-      when /^(Device):/
+      when /^(Device).*/
         stage = :device
         headers = line.gsub(/%/, 'pct_').split(/\s+/).map { |h| h.gsub(/\//, '_per_') }
         headers.shift


### PR DESCRIPTION
This fix issues with the new version of iostat package in Ubuntu 18 and Fedora 28.
The output of the command in the device session changes from `Device:` to `Device`.
The new simple regexp include both cases.

## Pull Request Checklist

Fix #12 issue https://github.com/sensu-plugins/sensu-plugins-io-checks/issues/12

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
